### PR TITLE
Change help message to 'sync' instead 'import contacts'

### DIFF
--- a/user.go
+++ b/user.go
@@ -207,7 +207,7 @@ func (user *User) Login(roomID types.MatrixRoomID) {
 	user.JID = strings.Replace(user.Conn.Info.Wid, whatsappExt.OldUserSuffix, whatsappExt.NewUserSuffix, 1)
 	user.Session = &session
 	user.Update()
-	_, err = bot.SendNotice(roomID, "Successfully logged in. Now, you may ask for `import contacts`.")
+	_, err = bot.SendNotice(roomID, "Successfully logged in. Now, you may ask for `sync [--create]`.")
 	if err != nil {
 		user.log.Warnln("Failed to send login confirmation to user:", err)
 	}


### PR DESCRIPTION
After user succesfully sets up bridge, bot will tell what to do next. This info had still old command so I updated message to reflect new 'sync' directive.