### PR TITLE
Disallow using session commands when not logged in

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -79,18 +79,27 @@ func (handler *CommandHandler) Handle(roomID types.MatrixRoomID, user *User, mes
 	switch cmd {
 	case "login":
 		handler.CommandLogin(ce)
-	case "logout":
-		handler.CommandLogout(ce)
 	case "help":
 		handler.CommandHelp(ce)
-	case "sync":
-		handler.CommandSync(ce)
-	case "list":
-		handler.CommandList(ce)
-	case "open":
-		handler.CommandOpen(ce)
-	case "pm":
-		handler.CommandPM(ce)
+	case "logout", "sync", "list", "open", "pm":
+		if ce.User.Conn == nil {
+			ce.Reply("You are not logged in.")
+			ce.Reply("Please use the login command to log into WhatsApp.")
+			return
+		}
+
+		switch cmd {
+		case "logout":
+			handler.CommandLogout(ce)
+		case "sync":
+			handler.CommandSync(ce)
+		case "list":
+			handler.CommandList(ce)
+		case "open":
+			handler.CommandOpen(ce)
+		case "pm":
+			handler.CommandPM(ce)
+		}
 	default:
 		ce.Reply("Unknown Command")
 	}
@@ -183,6 +192,7 @@ const cmdListHelp = `list - Get a list of all contacts and groups.`
 func (handler *CommandHandler) CommandList(ce *CommandEvent) {
 	var contacts strings.Builder
 	var groups strings.Builder
+
 	for jid, contact := range ce.User.Conn.Store.Contacts {
 		if strings.HasSuffix(jid, whatsappExt.NewUserSuffix) {
 			_, _ = fmt.Fprintf(&contacts, "* %s / %s - `%s`\n", contact.Name, contact.Notify, contact.Jid[:len(contact.Jid)-len(whatsappExt.NewUserSuffix)])
@@ -198,6 +208,7 @@ const cmdOpenHelp = `open <_group JID_> - Open a group chat portal.`
 func (handler *CommandHandler) CommandOpen(ce *CommandEvent) {
 	if len(ce.Args) == 0 {
 		ce.Reply("**Usage:** `open <group JID>`")
+		return
 	}
 
 	user := ce.User


### PR DESCRIPTION
This fixes panics that happen because the handlers assume the user is logged
in when the command is executed.

I'm not sure on the code style. A switch inside a switch is a bit ugly, and error prone. I would be happy to change it if desired!

Example of a panic that happened:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x928d7c]

goroutine 127 [running]:
main.(*CommandHandler).CommandList(0xc0001783c0, 0xc00016bef8)
	/build/commands.go:186 +0x6c
main.(*CommandHandler).Handle(0xc0001783c0, 0xc000455920, 0x1b,
0xc0002480c0, 0xc000250470, 0x4)
	/build/commands.go:89 +0x1f3
main.(*MatrixHandler).HandleMessage(0xc000176db0, 0xc0001ae6c0)
	/build/matrix.go:161 +0x203
created by maunium.net/go/mautrix-appservice.(*EventProcessor).Start