### PR TITLE
set default permission to invite bots to matrix room of whatsapp-bridge

### DIFF
--- a/config/bridge.go
+++ b/config/bridge.go
@@ -50,6 +50,8 @@ type BridgeConfig struct {
 	InviteOwnPuppetForBackfilling bool `yaml:"invite_own_puppet_for_backfilling"`
 	PrivateChatPortalMeta         bool `yaml:"private_chat_portal_meta"`
 
+	AllowUserInvite         bool `yaml:"allow_user_invite"`
+
 	CommandPrefix string `yaml:"command_prefix"`
 
 	Permissions PermissionConfig `yaml:"permissions"`

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -101,6 +101,10 @@ bridge:
     # but causes room avatar/name bugs.
     private_chat_portal_meta: false
 
+    # Allow invite permission for user. User can invite any bots to room with whatsapp 
+    # users (private chat and groups)
+    allow_user_invite: false
+
     # The prefix for commands. Only required in non-management rooms.
     command_prefix: "!wa"
 

--- a/portal.go
+++ b/portal.go
@@ -460,13 +460,17 @@ func (portal *Portal) Sync(user *User, contact whatsapp.Contact) {
 func (portal *Portal) GetBasePowerLevels() *mautrix.PowerLevels {
 	anyone := 0
 	nope := 99
+	invite := 0
+	if portal.bridge.Config.Bridge.AllowUserInvite {
+		invite = 99
+	}
 	return &mautrix.PowerLevels{
 		UsersDefault:    anyone,
 		EventsDefault:   anyone,
 		RedactPtr:       &anyone,
 		StateDefaultPtr: &nope,
 		BanPtr:          &nope,
-		InvitePtr:       &anyone,
+		InvitePtr:       &invite,
 		Users: map[string]int{
 			portal.MainIntent().UserID: 100,
 		},

--- a/portal.go
+++ b/portal.go
@@ -460,9 +460,9 @@ func (portal *Portal) Sync(user *User, contact whatsapp.Contact) {
 func (portal *Portal) GetBasePowerLevels() *mautrix.PowerLevels {
 	anyone := 0
 	nope := 99
-	invite := 0
+	invite := 99
 	if portal.bridge.Config.Bridge.AllowUserInvite {
-		invite = 99
+		invite = 0
 	}
 	return &mautrix.PowerLevels{
 		UsersDefault:    anyone,

--- a/portal.go
+++ b/portal.go
@@ -466,7 +466,7 @@ func (portal *Portal) GetBasePowerLevels() *mautrix.PowerLevels {
 		RedactPtr:       &anyone,
 		StateDefaultPtr: &nope,
 		BanPtr:          &nope,
-		InvitePtr:       &nope,
+		InvitePtr:       &anyone,
 		Users: map[string]int{
 			portal.MainIntent().UserID: 100,
 		},


### PR DESCRIPTION
This patch allow matrix user (which use whatsapp-bridge) invite to room any other bots, which can help matrix user. 
For example - bot, which translate voice messages to text:
https://github.com/progserega/voice2textMatrix