### PR TITLE
Remove command prefix from reconnect prompt

### DIFF
--- a/user.go
+++ b/user.go
@@ -183,8 +183,8 @@ func (user *User) Connect(evenIfNoSession bool) bool {
 	conn, err := whatsapp.NewConn(timeout * time.Second)
 	if err != nil {
 		user.log.Errorln("Failed to connect to WhatsApp:", err)
-		msg := format.RenderMarkdown(fmt.Sprintf("\u26a0 Failed to connect to WhatsApp server. " +
-			"This indicates a network problem on the bridge server. See bridge logs for more info."))
+		msg := format.RenderMarkdown("\u26a0 Failed to connect to WhatsApp server. "+
+			"This indicates a network problem on the bridge server. See bridge logs for more info.")
 		_, _ = user.bridge.Bot.SendMessageEvent(user.ManagementRoom, mautrix.EventMessage, msg)
 		return false
 	}
@@ -202,9 +202,8 @@ func (user *User) RestoreSession() bool {
 			return true
 		} else if err != nil {
 			user.log.Errorln("Failed to restore session:", err)
-			msg := format.RenderMarkdown(fmt.Sprintf("\u26a0 Failed to connect to WhatsApp. Make sure WhatsApp "+
-				"on your phone is reachable and use `reconnect` to try connecting again.",
-			))
+			msg := format.RenderMarkdown("\u26a0 Failed to connect to WhatsApp. Make sure WhatsApp "+
+				"on your phone is reachable and use `reconnect` to try connecting again.")
 			_, _ = user.bridge.Bot.SendMessageEvent(user.ManagementRoom, mautrix.EventMessage, msg)
 			return false
 		}

--- a/user.go
+++ b/user.go
@@ -203,8 +203,8 @@ func (user *User) RestoreSession() bool {
 		} else if err != nil {
 			user.log.Errorln("Failed to restore session:", err)
 			msg := format.RenderMarkdown(fmt.Sprintf("\u26a0 Failed to connect to WhatsApp. Make sure WhatsApp "+
-				"on your phone is reachable and use `%s reconnect` to try connecting again.",
-				user.bridge.Config.Bridge.CommandPrefix))
+				"on your phone is reachable and use `reconnect` to try connecting again.",
+			))
 			_, _ = user.bridge.Bot.SendMessageEvent(user.ManagementRoom, mautrix.EventMessage, msg)
 			return false
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1342360/61281191-272fba00-a7b1-11e9-9fa9-be687fb129e3.png)

When WhatsApp disconnected, this error would appear in a 1-1 room. Since the command prefix is never used in this room it's a little confusing.

This PR removes the command prefix from the error message.