### PR TITLE
Fix room topic length

### DIFF
--- a/database/upgrades/2019-11-12-fix-room-topic-length.go
+++ b/database/upgrades/2019-11-12-fix-room-topic-length.go
@@ -1,0 +1,16 @@
+package upgrades
+
+import (
+	"database/sql"
+)
+
+func init() {
+	upgrades[11] = upgrade{"Adjust the length of column topic in portal", func(tx *sql.Tx, ctx context) error {
+		if ctx.dialect == SQLite {
+			// SQLite doesn't support constraint updates, but it isn't that careful with constraints anyway.
+			return nil
+		}
+		_, err := tx.Exec(`ALTER TABLE portal ALTER COLUMN topic TYPE VARCHAR(512)`)
+		return err
+	}}
+}

--- a/database/upgrades/upgrades.go
+++ b/database/upgrades/upgrades.go
@@ -28,7 +28,7 @@ type upgrade struct {
 	fn      upgradeFunc
 }
 
-const NumberOfUpgrades = 11
+const NumberOfUpgrades = 12
 
 var upgrades [NumberOfUpgrades]upgrade
 


### PR DESCRIPTION
Room topics in WhatsApp do have a maximum length of 512.
Currently, the column topic is described as VARCHAR(255), which leads to the following error:

Whenever you accept an invitation from a WhatsApp groups with a topic above 255 characters, you get added and everything seems to work well. However, PostgreSQL throws the following error:

```
STATEMENT:  UPDATE portal SET mxid=$1, name=$2, topic=$3, avatar=$4, avatar_url=$5 WHERE jid=$6 AND receiver=$7,
ERROR:  value too long for type character varying(255)
```

Next time you restart the bridge, it has forgotten the reference in portal, so you get invited again and can't use the old room. 

This fix is PSQL only, because, as you already mentioned in https://github.com/tulir/mautrix-whatsapp/blob/3caca1b9a0eeb4521605d59416ede2ec8eec8cb0/database/upgrades/2019-05-16-message-delete-cascade.go#L10, SQLite doesn't really care about column lengths and the [recommended workaround](https://www.sqlite.org/faq.html#q11) is quite a mess.

