### PR TITLE
docs: Add documentation in the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,24 @@ implementation of the [sigalor/whatsapp-web-reveng](https://github.com/sigalor/w
 
 See the [docs](https://github.com/tulir/mautrix-whatsapp/blob/master/docs/bridge_setup.md) for setting up the bridge.
 
+See the [wiki](https://github.com/tulir/mautrix-whatsapp/wiki/Bridge-setup-with-Docker) for setting up the brdige with Docker.
+
 ### Connecting the brdige to WhatsApp
 
 See the [docs](https://github.com/tulir/mautrix-whatsapp/blob/master/docs/authentication.md) for setting up the bridge.
 
-### [Wiki](https://github.com/tulir/mautrix-whatsapp/wiki)
+### Setting up WhatsApp in an Android VM
+
+Documentation in progress. See the original documentation on the [wiki](https://github.com/tulir/mautrix-whatsapp/wiki/Android-VM-Setup).
+
+### The older wiki
+
+The [Wiki](https://github.com/tulir/mautrix-whatsapp/wiki) contains all of the original documentation.
 
 ### [Features & Roadmap](https://github.com/tulir/mautrix-whatsapp/blob/master/ROADMAP.md)
 
 ## Discussion
 
 Matrix room: [#whatsapp:maunium.net](https://matrix.to/#/#whatsapp:maunium.net)
+
+In case you need to upload your logs somewhere, be aware that they contain your contacts' and your phone numbers. Strip them out with `| sed -r 's/[0-9]{10,}/📞/g'`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ implementation of the [sigalor/whatsapp-web-reveng](https://github.com/sigalor/w
 
 See the [docs](https://github.com/tulir/mautrix-whatsapp/blob/master/docs/bridge_setup.md) for setting up the bridge.
 
+### Connecting the brdige to WhatsApp
+
+See the [docs](https://github.com/tulir/mautrix-whatsapp/blob/master/docs/authentication.md) for setting up the bridge.
+
 ### [Wiki](https://github.com/tulir/mautrix-whatsapp/wiki)
 
 ### [Features & Roadmap](https://github.com/tulir/mautrix-whatsapp/blob/master/ROADMAP.md)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 A Matrix-WhatsApp puppeting bridge based the [Rhymen/go-whatsapp](https://github.com/Rhymen/go-whatsapp)
 implementation of the [sigalor/whatsapp-web-reveng](https://github.com/sigalor/whatsapp-web-reveng) project.
 
+### Setting up the Bridge
+
+See the [docs](https://github.com/tulir/mautrix-whatsapp/blob/master/docs/bridge_setup.md) for setting up the bridge.
+
 ### [Wiki](https://github.com/tulir/mautrix-whatsapp/wiki)
 
 ### [Features & Roadmap](https://github.com/tulir/mautrix-whatsapp/blob/master/ROADMAP.md)
 
 ## Discussion
+
 Matrix room: [#whatsapp:maunium.net](https://matrix.to/#/#whatsapp:maunium.net)

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,23 @@
+# Authentication
+
+## Logging In
+
+ 1. Start a chat with the bridge bot.
+     - You can for instance create a new room and type `/invite @whatsappbot:matrix.example.com` to invite the bot (assuming you did not change the bot username in config and your Synapse server is running at matrix.example.com).
+    - The bot should say "This room has been registered as your bridge management/status room." if you started the chat correctly.
+    - If the bot doesn't work check the logs from the bridge.
+    - NOTE: Riot (and other clients) might report that the bot does not exist, just invite it anyway.
+ 2. Send `login` to the bot
+ 3. Log in by scanning the QR code. If the code expires before you scan it, the bridge will send an error to notify you.
+    1. Open WhatsApp on your phone.
+    2. Tap Menu or Settings and select WhatsApp Web.
+    3. Point your phone at the image sent by the bot to capture the code.
+    - **NOTE**: The bridge will cycle through multiple QR images by default. You need to be ready to scan the images.
+ 4. Finally, the bot should inform you of a successful login and the bridge should start creating portal rooms for all your WhatsApp groups and private chats.
+ 5. You might be interested in using the `login-matrix <access token>` command for Matrix puppeting (see https://github.com/tulir/mautrix-whatsapp/issues/16). In Riot, you can find your access token under Settings > Help > Access token.
+
+Please note that the bridge uses the web API, so your phone must be connected to the internet for the bridge to work. The WhatsApp app doesn't need to be running all the time, but it needs to be allowed to wake up when receiving messages (should work by default). The web API is used instead of the main client API to avoid bans (WhatsApp will ban unofficial clients).
+
+## Logging Out
+
+Simply run the `logout` management command.

--- a/docs/bridge_setup.md
+++ b/docs/bridge_setup.md
@@ -1,0 +1,33 @@
+# Bridge setup
+
+## Requirements
+
+ - go 1.12+
+ - A Matrix homeserver that supports application services (e.g. [Synapse](https://github.com/matrix-org/synapse).)
+ - A WhatsApp client running on a phone or in an emulated Android VM.
+
+## Setup
+
+ 1. Clone the repo with `git clone https://github.com/tulir/mautrix-whatsapp.git`
+ 2. Run `go build` to fetch dependencies and compile.
+     - If your distro doesn't support go 1.12+ you can download the latest version from: https://golang.org/dl/
+     - You will then need to export the path using something like this:
+```
+		export GOROOT=$HOME/mautrix-whatsapp/go
+		export GOPATH=$HOME/mautrix-whatsapp/go/work
+		export PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+```
+ 3. Copy example-config.yaml to config.yaml
+ 4. Update the config to your liking.
+    - You need to make sure that the `address` and `domain` field point to your homeserver.
+    - You will also need to add your user of admin user under the `permissions` section.
+ 5. Generate the appservice registration file by running `./mautrix-whatsapp -g`.
+     - You can use the -c and -r flags to change the location of the config and registration files. They default to config.yaml and registration.yaml respectively.
+ 6. Add the path to the registration file to your synapse `homeserver.yaml` under `app_service_config_files`. You will then need to restart the synapse server. Remember to restart it everytime the registration file is regenerated.
+ 7. Run the bridge with ./mautrix-whatsapp.
+
+## Updating
+
+ 1. Pull changes with `git pull`
+ 2. Recompile with `go build`
+ 3. Start the bridge again


### PR DESCRIPTION
The GitHub wiki does't allow others to contribute to the documentation.
Although the docuement is very useful it ends up being a little bare in
some apsects. This PR tries to add more details to the documentation to
help people get started. It also moves the docs into the project so that
it is easier for others to contibute.

The idea here is to move all the documentation accross if this is
accepted.

Signed-off-by: Alistair Francis <alistair@alistair23.me>