### PR TITLE
Added the ability to receive stickers "in real time"

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/tulir/go-whatsapp v0.0.2-0.20190830212741-33ca6ee47cf5 h1:0pUczFGOo4s
 github.com/tulir/go-whatsapp v0.0.2-0.20190830212741-33ca6ee47cf5/go.mod h1:u3Hdptbz3iB5y/NEoSKgsp9hBzUlm0A5OrLMVdENAX8=
 github.com/tulir/go-whatsapp v0.0.2-0.20190903182221-4e1a838ff3ba h1:exEcedSHn0qEZ1iwNwFF5brEuflhMScjFyyzmxUA+og=
 github.com/tulir/go-whatsapp v0.0.2-0.20190903182221-4e1a838ff3ba/go.mod h1:u3Hdptbz3iB5y/NEoSKgsp9hBzUlm0A5OrLMVdENAX8=
+github.com/tulir/go-whatsapp v0.0.2-0.20191109203156-c477dae1c7e9 h1:WyLOadcpkAvoyaGfUvBgj/mTHetzliBGFioEEtM+Ac8=
 github.com/tulir/go-whatsapp v0.0.2-0.20191109203156-c477dae1c7e9/go.mod h1:ustkccVUt0hOuKikjFb6b4Eray6At5djkcKYYu4+Lco=
 golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
@@ -73,6 +74,7 @@ maunium.net/go/mautrix v0.1.0-alpha.3.0.20190622085722-6406f15cb8e3 h1:oVabjOi2r
 maunium.net/go/mautrix v0.1.0-alpha.3.0.20190622085722-6406f15cb8e3/go.mod h1:O+QWJP3H7BZEzIBSrECKpnpRnEKBwaoWVEu/yZwVwxg=
 maunium.net/go/mautrix v0.1.0-alpha.3.0.20190825132810-9d870654e9d2 h1:0iVxLLAOSBqtJqhIjW9EbblMsaSYoCJRo5mHPZnytUk=
 maunium.net/go/mautrix v0.1.0-alpha.3.0.20190825132810-9d870654e9d2/go.mod h1:O+QWJP3H7BZEzIBSrECKpnpRnEKBwaoWVEu/yZwVwxg=
+maunium.net/go/mautrix v0.1.0-alpha.3.0.20191110191816-178ce1f1561d h1:lfEHd6diaoKLdZvVNcmBF9kD667xWw+x7iXlvfpEd00=
 maunium.net/go/mautrix v0.1.0-alpha.3.0.20191110191816-178ce1f1561d/go.mod h1:O+QWJP3H7BZEzIBSrECKpnpRnEKBwaoWVEu/yZwVwxg=
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190618052224-6e6c9bb47548 h1:ni1nqs+2AOO+g1ND6f2W0pMcb6sIDVqzerXosO+pI2g=
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190618052224-6e6c9bb47548/go.mod h1:yVWU0gvIHIXClgyVnShiufiDksFbFrBqHG9lDAYcmGI=
@@ -86,4 +88,5 @@ maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190830063827-e7dcd7e42e7c h
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190830063827-e7dcd7e42e7c/go.mod h1:FJRRpH5+p3wCfEt6u/3kMeu9aGX/pk2PqtvjRDRW74w=
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190901152202-40639f5932be h1:sSBx9AGR4iYHRFwljqNwxXFtbY2bKLJHgI9B4whAU8I=
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20190901152202-40639f5932be/go.mod h1:FJRRpH5+p3wCfEt6u/3kMeu9aGX/pk2PqtvjRDRW74w=
+maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20191110192030-cd699619a163 h1:+tWThOHlyIW2VITR4A05wuhixu0AH8iZZ/Ha7AwkAys=
 maunium.net/go/mautrix-appservice v0.1.0-alpha.3.0.20191110192030-cd699619a163/go.mod h1:ST7YYCoHtFC4c7/Iga8W5wwKXyxjwVh4DlsnyIU6rYw=

--- a/portal.go
+++ b/portal.go
@@ -964,6 +964,7 @@ func (portal *Portal) HandleMediaMessage(source *User, download func() ([]byte, 
 
 	// synapse doesn't handle webp well, so we convert it. This can be dropped once https://github.com/matrix-org/synapse/issues/4382 is fixed
 	if mimeType == "image/webp" {
+		fmt.Sprintf("Converting webp")
 		img, err := webp.Decode(bytes.NewReader(data))
 		if err != nil {
 			portal.log.Errorfln("Failed to decode media for %s: %v", err)

--- a/portal.go
+++ b/portal.go
@@ -964,7 +964,6 @@ func (portal *Portal) HandleMediaMessage(source *User, download func() ([]byte, 
 
 	// synapse doesn't handle webp well, so we convert it. This can be dropped once https://github.com/matrix-org/synapse/issues/4382 is fixed
 	if mimeType == "image/webp" {
-		fmt.Sprintf("Converting webp")
 		img, err := webp.Decode(bytes.NewReader(data))
 		if err != nil {
 			portal.log.Errorfln("Failed to decode media for %s: %v", err)

--- a/user.go
+++ b/user.go
@@ -619,6 +619,10 @@ func (user *User) HandleDocumentMessage(message whatsapp.DocumentMessage) {
 	user.putMessage(PortalMessage{message.Info.RemoteJid, user, message, message.Info.Timestamp})
 }
 
+func (user *User) HandleStickerMessage(message whatsapp.StickerMessage) {
+	user.putMessage(PortalMessage{message.Info.RemoteJid, user, message, message.Info.Timestamp})
+}
+
 func (user *User) HandleMessageRevoke(message whatsappExt.MessageRevocation) {
 	user.putMessage(PortalMessage{message.RemoteJid, user, message, 0})
 }


### PR DESCRIPTION
Someone added the ability to receive stickers a while back, but it only worked when backfilling. This fixes that so you can just receive stickers "immediately" (though it may take a sec because of converting webp -> png). 

Testing has shown however that you can only receive stickers sent by other people. Stickers sent by the user themselves seem to be received twice, once only partly without the url and once afterwards fully with the url, the first time causes the second time to drop, but this will require more testing.

In any case, you should be able to receive stickers sent by other people with this.