### PR TITLE
Fix #134, let whatsapp deal with mimetypes

### DIFF
--- a/portal.go
+++ b/portal.go
@@ -987,9 +987,10 @@ func (portal *Portal) HandleMediaMessage(source *User, download func() ([]byte, 
 	}
 
 	// WhatsApp sends incorrect mime types 3:<
-	if detected := http.DetectContentType(data); detected != "application/octet-stream" {
-		mimeType = detected
-	}
+	portal.log.Debugfln("Before conversion: %s", mimeType)
+	//if detected := http.DetectContentType(data); detected != "application/octet-stream" {
+	//	mimeType = detected
+	//}
 
 	// synapse doesn't handle webp well, so we convert it. This can be dropped once https://github.com/matrix-org/synapse/issues/4382 is fixed
 	if mimeType == "image/webp" {

--- a/portal.go
+++ b/portal.go
@@ -986,12 +986,6 @@ func (portal *Portal) HandleMediaMessage(source *User, download func() ([]byte, 
 		return
 	}
 
-	// WhatsApp sends incorrect mime types 3:<
-	portal.log.Debugfln("Before conversion: %s", mimeType)
-	//if detected := http.DetectContentType(data); detected != "application/octet-stream" {
-	//	mimeType = detected
-	//}
-
 	// synapse doesn't handle webp well, so we convert it. This can be dropped once https://github.com/matrix-org/synapse/issues/4382 is fixed
 	if mimeType == "image/webp" {
 		img, err := webp.Decode(bytes.NewReader(data))


### PR DESCRIPTION
A while back you implemented a fix because WhatsApp was sending incorrect mime type (3:<). However after some testing I found that WhatsApp now sends correct mimetypes, and the fix you implemented caused .ogg voice messages to instead be seen as .ogx (as described in #134). Removing this workaround seems to not break anything, and voice messages now correctly get bridged as .oga files (which are just an updated version of .ogg). 

Though, since you are the person who ran into this problem in the first place, it might be an idea to check whether WhatsApp truly sends all mimetypes correctly.

Fixes #134 