### PR TITLE
Improve communities doc in config

### DIFF
--- a/example-config.yaml
+++ b/example-config.yaml
@@ -55,7 +55,10 @@ bridge:
     # {{.Short}}  - short display name from contact list
     displayname_template: "{{if .Notify}}{{.Notify}}{{else}}{{.Jid}}{{end}} (WA)"
     # Localpart template for per-user room grouping community IDs.
-    # The bridge will create these communities and add all of the specific user's portals to the community.
+    # On startup, the bridge will try to create these communities, add all of the specific user's
+    # portals to the community, and invite the Matrix user to it.
+    # (Note that, by default, non-admins might not have your homeserver's permission to create
+    #  communities.)
     # {{.Localpart}} is the MXID localpart and {{.Server}} is the MXID server part of the user.
     community_template: whatsapp_{{.Localpart}}={{.Server}}
 


### PR DESCRIPTION
I was struggling trying to get the bridge to make a community for me. Turns out Synapse doesn't allow it by default.
Even though the bridge's logs give insight in the issue, it would be great to have the config explain it as well.

I also thought about mentioning the specific Synapse config value, but it wouldn't be clean to have things specific to a single homeserver implementation here.

Thus change hardly deserves its own pull request, but oh well.