### PR TITLE
Fix #142

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -247,12 +247,13 @@ func (handler *CommandHandler) CommandReconnect(ce *CommandEvent) {
 	} else if err == whatsapp.ErrLoginInProgress {
 		ce.Reply("A login or reconnection is already in progress.")
 		return
+	} else if err == whatsapp.ErrAlreadyLoggedIn {
+		ce.Reply("You were already connected.")
+		return
 	}
 	if err != nil {
 		ce.User.log.Warnln("Error while reconnecting:", err)
-		if err == whatsapp.ErrAlreadyLoggedIn {
-			ce.Reply("You were already connected.")
-		} else if err.Error() == "restore session connection timed out" {
+		if err.Error() == "restore session connection timed out" {
 			ce.Reply("Reconnection timed out. Is WhatsApp on your phone reachable?")
 		} else {
 			ce.Reply("Unknown error while reconnecting: %v", err)

--- a/provisioning.go
+++ b/provisioning.go
@@ -178,15 +178,16 @@ func (prov *ProvisioningAPI) Reconnect(w http.ResponseWriter, r *http.Request) {
 			ErrCode: "login in progress",
 		})
 		return
+	} else if err == whatsapp.ErrAlreadyLoggedIn {
+		jsonResponse(w, http.StatusConflict, Error{
+			Error:   "You were already connected.",
+			ErrCode: err.Error(),
+		})
+		return
 	}
 	if err != nil {
 		user.log.Warnln("Error while reconnecting:", err)
-		if err == whatsapp.ErrAlreadyLoggedIn {
-			jsonResponse(w, http.StatusConflict, Error{
-				Error:   "You were already connected.",
-				ErrCode: err.Error(),
-			})
-		} else if err.Error() == "restore session connection timed out" {
+		if err.Error() == "restore session connection timed out" {
 			jsonResponse(w, http.StatusForbidden, Error{
 				Error:   "Reconnection timed out. Is WhatsApp on your phone reachable?",
 				ErrCode: err.Error(),


### PR DESCRIPTION
Don't disconnect when trying to reconnect and receiving a ErrAlreadyLoggedIn as a result.

At the moment, the bridge disconnects the WhatsApp connection when executing a 'reconnect' command, and an ErrAlreadyLoggedIn is returned in the process.

Fixes #142 