### PR TITLE
Fix #142

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -247,12 +247,13 @@ func (handler *CommandHandler) CommandReconnect(ce *CommandEvent) {
 	} else if err == whatsapp.ErrLoginInProgress {
 		ce.Reply("A login or reconnection is already in progress.")
 		return
+	} else if err == whatsapp.ErrAlreadyLoggedIn {
+		ce.Reply("You were already connected.")
+		return
 	}
 	if err != nil {
 		ce.User.log.Warnln("Error while reconnecting:", err)
-		if err == whatsapp.ErrAlreadyLoggedIn {
-			ce.Reply("You were already connected.")
-		} else if err.Error() == "restore session connection timed out" {
+		if err.Error() == "restore session connection timed out" {
 			ce.Reply("Reconnection timed out. Is WhatsApp on your phone reachable?")
 		} else {
 			ce.Reply("Unknown error while reconnecting: %v", err)

--- a/provisioning.go
+++ b/provisioning.go
@@ -156,7 +156,18 @@ func (prov *ProvisioningAPI) Reconnect(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
-	err := user.Conn.Restore()
+
+	wasConnected := true
+	sess, err := user.Conn.Disconnect()
+	if err == whatsapp.ErrNotConnected {
+		wasConnected = false
+	} else if err != nil {
+		user.log.Warnln("Error while disconnecting:", err)
+	} else if len(sess.Wid) > 0 {
+		user.SetSession(&sess)
+	}
+
+	err = user.Conn.Restore()
 	if err == whatsapp.ErrInvalidSession {
 		if user.Session != nil {
 			user.log.Debugln("Got invalid session error when reconnecting, but user has session. Retrying using RestoreWithSession()...")
@@ -209,7 +220,15 @@ func (prov *ProvisioningAPI) Reconnect(w http.ResponseWriter, r *http.Request) {
 	}
 	user.ConnectionErrors = 0
 	user.PostLogin()
-	jsonResponse(w, http.StatusOK, Response{true, "Reconnected successfully."})
+
+	var msg string
+	if wasConnected {
+		msg = "Reconnected successfully."
+	} else {
+		msg = "Connected successfully."
+	}
+
+	jsonResponse(w, http.StatusOK, Response{true, msg})
 }
 
 func (prov *ProvisioningAPI) Ping(w http.ResponseWriter, r *http.Request) {

--- a/provisioning.go
+++ b/provisioning.go
@@ -178,15 +178,16 @@ func (prov *ProvisioningAPI) Reconnect(w http.ResponseWriter, r *http.Request) {
 			ErrCode: "login in progress",
 		})
 		return
+	} else if err == whatsapp.ErrAlreadyLoggedIn {
+		jsonResponse(w, http.StatusConflict, Error{
+			Error:   "You were already connected.",
+			ErrCode: err.Error(),
+		})
+		return
 	}
 	if err != nil {
 		user.log.Warnln("Error while reconnecting:", err)
-		if err == whatsapp.ErrAlreadyLoggedIn {
-			jsonResponse(w, http.StatusConflict, Error{
-				Error:   "You were already connected.",
-				ErrCode: err.Error(),
-			})
-		} else if err.Error() == "restore session connection timed out" {
+		if err.Error() == "restore session connection timed out" {
 			jsonResponse(w, http.StatusForbidden, Error{
 				Error:   "Reconnection timed out. Is WhatsApp on your phone reachable?",
 				ErrCode: err.Error(),


### PR DESCRIPTION
Don't disconnect when trying to reconnect and receiving a ErrAlreadyLoggedIn as a result.

At the moment, the bridge disconnescts the WhatsApp connection when executing a 'reconnect' command, and an ErrAlreadyLoggedIn is returned in the process.

Edit: Proposed a different fix in a second commit. Disconnect always before doing a Restore in reconnect. This is more in alignment with the command's name, reconnect :p , so it is assumed its what users want.

Fixes #142