### PR TITLE
Fix out of range access when requesting last page with `list`

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -609,7 +609,11 @@ func (handler *CommandHandler) CommandList(ce *CommandEvent) {
 		}
 		return
 	}
-	result = result[(page-1)*max : page*max]
+	lastIndex := page*max
+	if lastIndex > len(result) {
+		lastIndex = len(result)
+	}
+	result = result[(page-1)*max : lastIndex]
 	ce.Reply("### %s (page %d of %d)\n\n%s", typeName, page, pages, strings.Join(result, "\n"))
 }
 


### PR DESCRIPTION
Prevent command `list` from failing with out of range access error if number
of entries is lower than maximum entry index for that page a.k.a.
if `len(result) < page*max`