### PR TITLE
Prometheus Metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,19 +78,12 @@ var (
 		Name: "whatsappbridge_private_chats_total",
 		Help: "Total number of private whatsapp chats",
 	})
+	// group chats
 	numGroups = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "whatsappbridge_group_chats_total",
 		Help: "Total number of whatsapp group chats",
 	})
 	// messages
-/*	numMessagesRx = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "whatsappbridge_messages_received_total",
-		Help: "Total number of Messages received from whatsapp",
-	})
-	numMessagesTx = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "whatsappbridge_messages_send_total",
-		Help: "Total number of Messages send from Matrix to whatsapp",
-	})*/
 	numMessagesTotal = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "whatsappbridge_messages_bridged_total",
 		Help: "Total number of bridged Messages",
@@ -102,64 +95,58 @@ func recordMetrics(bridge *Bridge) {
 		for {
 			var val float64 = 0
 			var row, err = bridge.DB.Query("SELECT COUNT(*) FROM puppet")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numPuppets.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numPuppets.Set(val)
 
 			row, err = bridge.DB.Query("SELECT COUNT(*) FROM portal WHERE topic='WhatsApp private chat'")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numPrivate.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numPrivate.Set(val)
 
 			row, err = bridge.DB.Query("SELECT COUNT(*) FROM portal WHERE name NOT LIKE ''")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numGroups.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numGroups.Set(val)
 
 			row, err = bridge.DB.Query("SELECT COUNT(*) FROM user")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numUsers.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numUsers.Set(val)
 
 			row, err = bridge.DB.Query("SELECT COUNT(*) FROM mx_room_state")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numRooms.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numRooms.Set(val)
 
 			row, err = bridge.DB.Query("SELECT COUNT(*) FROM message")
-			if err != nil || row == nil {
-				break
+			if err == nil || row != nil {
+				defer row.Close()
+				for row.Next() {
+					row.Scan(&val)
+				}
+				numMessagesTotal.Set(val)
 			}
-			defer row.Close()
-			for row.Next() {
-				row.Scan(&val)
-			}
-			numMessagesTotal.Set(val)
 
 			time.Sleep(10 * time.Second)
 		}

--- a/main.go
+++ b/main.go
@@ -482,7 +482,7 @@ func (bridge *Bridge) Main() {
 	bridge.Log.Infoln("Bridge started!")
 
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":9093", nil)
+	http.ListenAndServe("127.0.0.1:9093", nil)
 
 	c := make(chan os.Signal)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)

--- a/portal.go
+++ b/portal.go
@@ -855,6 +855,7 @@ func (portal *Portal) CreateMatrixRoom(user *User) error {
 			},
 		},
 	}
+	bridgeInfoStateKey := fmt.Sprintf("net.maunium.whatsapp://whatsapp/%s", portal.Key.JID)
 	initialState := []*event.Event{{
 		Type: event.StatePowerLevels,
 		Content: event.Content{
@@ -863,10 +864,12 @@ func (portal *Portal) CreateMatrixRoom(user *User) error {
 	}, {
 		Type:    StateBridgeInfo,
 		Content: bridgeInfo,
+		StateKey: &bridgeInfoStateKey,
 	}, {
 		// TODO remove this once https://github.com/matrix-org/matrix-doc/pull/2346 is in spec
 		Type:    StateHalfShotBridgeInfo,
 		Content: bridgeInfo,
+		StateKey: &bridgeInfoStateKey,
 	}}
 	if !portal.AvatarURL.IsEmpty() {
 		initialState = append(initialState, &event.Event{


### PR DESCRIPTION
Making bridge metrics available on `http://localhost:9093/metrics`
The values are updated every 10 sseconds.
### Exported metrics
- Number of puppets
- Number of private chats
- Number of group chats
- Number of messages
- Number of rooms
- Number of users

### Things that should be improved (but I don't know how)
- Add options to the config file for:
  - listening port
  - listening ip
  - refresh interval
  - enable/disable metrics endpoint
- Add more metrics:
  - messages (matrix -> whatsapp)
  - messages (whatsapp -> matrix)
  - connection failures