### PR TITLE
Set RestrictMessageSending in portal create+update

### DIFF
--- a/whatsapp-ext/whatsapp.go
+++ b/whatsapp-ext/whatsapp.go
@@ -84,6 +84,8 @@ type GroupInfo struct {
 	NameSetTime int64  `json:"subjectTime"`
 	NameSetBy   string `json:"subjectOwner"`
 
+	Announce bool `json:"announce"` // Can only admins send messages?
+
 	Topic      string `json:"desc"`
 	TopicID    string `json:"descId"`
 	TopicSetAt int64  `json:"descTime"`


### PR DESCRIPTION
Fixes #228

Bridge didn't set the power level for message sending correctly when the bridge user is invited to a WA-group that was already set to 'announce'-mode (=only admins can send message).
It did already bridge it correctly when the setting is toggled while we're in the group. (Using ChatUpdate with ChatActionType Announce)

In this patch I've added a call to RestrictMessageSending in CreateMatrixRoom which should fix it for new groups bridge users join. I could have also added a state event in the initialState slice, instead of calling RestrictMessageSending separately, but that would make it more complex imo. Let you know if you'd want me to change it.

The extra call to RestrictMessageSending in UpdateMetadata is included to fix it for existing groups as well. Works perfectly here!

With best regards,

Remi