### PR TITLE
sync the name of custom puppet

### DIFF
--- a/user.go
+++ b/user.go
@@ -685,6 +685,14 @@ func (user *User) syncPuppets(contacts map[string]whatsapp.Contact) {
 	if contacts == nil {
 		contacts = user.Conn.Store.Contacts
 	}
+
+	if user.Conn != nil && user.Conn.Info != nil && len(user.Conn.Info.Wid) > 0 {
+		userJid := strings.Replace(user.Conn.Info.Wid, whatsappExt.OldUserSuffix, whatsappExt.NewUserSuffix, 1)
+		contacts[userJid] = whatsapp.Contact{
+			Name: user.Conn.Info.Pushname,
+			Jid: userJid,
+		}
+	}
 	user.log.Infoln("Syncing puppet info from contacts")
 	for jid, contact := range contacts {
 		if strings.HasSuffix(jid, whatsappExt.NewUserSuffix) {


### PR DESCRIPTION
currently, when the synchronization is completed, the user's own puppet name is not synchronized to the matrix.
for example, the puppet name in the historical message is "whatsapp_phonenumber".

this commit is optimized this.